### PR TITLE
FIX: Firefox pre 中的换行错误

### DIFF
--- a/site/assets/styles/simditor.css
+++ b/site/assets/styles/simditor.css
@@ -536,8 +536,8 @@
   font-size: 13px;
   font-family: 'monaco', 'Consolas', "Liberation Mono", Courier, monospace;
   /*overflow-x: auto;*/
-  white-space: pre;
   word-wrap: break-word;
+  white-space: pre-wrap;
 }
 .simditor .simditor-body code, .editor-style code {
   display: inline-block;

--- a/styles/simditor.css
+++ b/styles/simditor.css
@@ -536,8 +536,8 @@
   font-size: 13px;
   font-family: 'monaco', 'Consolas', "Liberation Mono", Courier, monospace;
   /*overflow-x: auto;*/
-  white-space: pre;
   word-wrap: break-word;
+  white-space: pre-wrap;
 }
 .simditor .simditor-body code, .editor-style code {
   display: inline-block;

--- a/styles/simditor.scss
+++ b/styles/simditor.scss
@@ -620,8 +620,8 @@ $simditor-button-height: 40px;
     font-size:13px;
     font-family: 'monaco', 'Consolas', "Liberation Mono", Courier, monospace;
     /*overflow-x: auto;*/
-    white-space: pre;
     word-wrap: break-word;
+    white-space: pre-wrap;
   }
 
   code {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1207465/5646446/23049afa-96b7-11e4-98cd-28be700073a6.png)

由于 Firefox 不支持 `word-break` 造成的。

http://stackoverflow.com/questions/7656753/ff-not-displaying-word-wrap-css-property