### PR TITLE
format 增加可配置白名单参数

### DIFF
--- a/lib/simditor.js
+++ b/lib/simditor.js
@@ -336,11 +336,19 @@ Formatter = (function(_super) {
       h3: ['data-indent'],
       h4: ['data-indent']
     };
-    return this.editor.body.on('click', 'a', (function(_this) {
+    if (this.editor.opts.formatter && this.editor.opts.formatter.allowedTags) {
+      this._allowedTags = this.editor.opts.formatter.allowedTags;
+    }
+    if (this.editor.opts.formatter) {
+      $.extend(this._allowedAttributes, this.editor.opts.formatter._allowedAttributes || {});
+    }
+    this.safeFormatter = typeof this.editor.opts.safeFormatter === 'undefined' ? true : this.editor.opts.safeFormatter;
+    this.editor.body.on('click', 'a', (function(_this) {
       return function(e) {
         return false;
       };
     })(this));
+    return console.log(this._allowedAttributes, this._allowedTags, this.safeFormatter, this.editor);
   };
 
   Formatter.prototype.decorate = function($el) {
@@ -460,7 +468,7 @@ Formatter = (function(_super) {
     }
     contents = $node.contents();
     isDecoration = $node.is('[class^="simditor-"]');
-    if ($node.is(this._allowedTags.join(',')) || isDecoration) {
+    if ($node.is(this._allowedTags.join(',')) || isDecoration || !this.safeFormatter) {
       if ($node.is('a') && ($childImg = $node.find('img')).length > 0) {
         $node.replaceWith($childImg);
         $node = $childImg;
@@ -469,12 +477,12 @@ Formatter = (function(_super) {
       if ($node.is('img') && $node.hasClass('uploading')) {
         $node.remove();
       }
-      if (!isDecoration) {
+      if (!(isDecoration || !this.safeFormatter)) {
         allowedAttributes = this._allowedAttributes[$node[0].tagName.toLowerCase()];
         _ref = $.makeArray($node[0].attributes);
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
           attr = _ref[_i];
-          if (!((allowedAttributes != null) && (_ref1 = attr.name, __indexOf.call(allowedAttributes, _ref1) >= 0))) {
+          if (!((allowedAttributes != null) && (_ref1 = attr.name, __indexOf.call(allowedAttributes, _ref1) >= 0) || !this.safeFormatter)) {
             $node.removeAttr(attr.name);
           }
         }
@@ -533,7 +541,7 @@ Formatter = (function(_super) {
           if (children.length > 0) {
             result += _this.clearHtml(children);
           }
-          if (lineBreak && i < contents.length - 1 && $node.is('br, p, div, li, tr, pre, address, artticle, aside, dl, figcaption, footer, h1, h2, h3, h4, header')) {
+          if (lineBreak && i < contents.length - 1 && $node.is('br, p, div, li, tr, pre, address, artticle, aside, dl, figcaption, footer, h1, h2, h3, h4, h5, h6, section, header')) {
             return result += '\n';
           }
         }

--- a/lib/simditor.js
+++ b/lib/simditor.js
@@ -343,12 +343,11 @@ Formatter = (function(_super) {
       $.extend(this._allowedAttributes, this.editor.opts.formatter._allowedAttributes || {});
     }
     this.safeFormatter = typeof this.editor.opts.safeFormatter === 'undefined' ? true : this.editor.opts.safeFormatter;
-    this.editor.body.on('click', 'a', (function(_this) {
+    return this.editor.body.on('click', 'a', (function(_this) {
       return function(e) {
         return false;
       };
     })(this));
-    return console.log(this._allowedAttributes, this._allowedTags, this.safeFormatter, this.editor);
   };
 
   Formatter.prototype.decorate = function($el) {

--- a/site/assets/_coffee/page-demo-format.coffee
+++ b/site/assets/_coffee/page-demo-format.coffee
@@ -1,0 +1,20 @@
+
+$ ->
+  # alert 12
+  toolbar= ['title', 'bold', 'italic', 'underline', 'strikethrough', 'color', '|', 'ol', 'ul', 'blockquote', 'code', 'table', '|', 'link', 'image', 'hr', '|', 'indent', 'outdent']
+  mobileToolbar=["bold","underline","strikethrough","color","ul","ol"]
+  toolbar = mobileToolbar if mobilecheck()
+  editor = new Simditor
+    textarea: $('#txt-content')
+    placeholder: '这里输入文字...'
+    toolbar: toolbar
+    pasteImage: true
+    defaultImage: 'assets/images/image.png'
+    upload: if location.search == '?upload' then {url: '/upload'} else false
+    safeFormatter: true
+    formatter:{
+      allowedTags: ['br', 'a', 'img', 'b', 'strong', 'i', 'u', 'font', 'p', 'ul', 'ol', 'li', 'blockquote', 'pre', 'h1', 'h2', 'h3', 'h4', 'hr', 'code', 'rect', 'h6'],
+      allowedAttributes: {
+        img: ['src', 'alt', 'width', 'height', 'data-image-src', 'data-image-size', 'data-image-name', 'data-non-image']
+      }
+    }

--- a/site/assets/scripts/page-demo-format.js
+++ b/site/assets/scripts/page-demo-format.js
@@ -1,0 +1,28 @@
+(function() {
+  $(function() {
+    var editor, mobileToolbar, toolbar;
+    toolbar = ['title', 'bold', 'italic', 'underline', 'strikethrough', 'color', '|', 'ol', 'ul', 'blockquote', 'code', 'table', '|', 'link', 'image', 'hr', '|', 'indent', 'outdent'];
+    mobileToolbar = ["bold", "underline", "strikethrough", "color", "ul", "ol"];
+    if (mobilecheck()) {
+      toolbar = mobileToolbar;
+    }
+    return editor = new Simditor({
+      textarea: $('#txt-content'),
+      placeholder: '这里输入文字...',
+      toolbar: toolbar,
+      pasteImage: true,
+      defaultImage: 'assets/images/image.png',
+      upload: location.search === '?upload' ? {
+        url: '/upload'
+      } : false,
+      safeFormatter: true,
+      formatter: {
+        allowedTags: ['br', 'a', 'img', 'b', 'strong', 'i', 'u', 'font', 'p', 'ul', 'ol', 'li', 'blockquote', 'pre', 'h1', 'h2', 'h3', 'h4', 'hr', 'code', 'rect', 'h6'],
+        allowedAttributes: {
+          img: ['src', 'alt', 'width', 'height', 'data-image-src', 'data-image-size', 'data-image-name', 'data-non-image']
+        }
+      }
+    });
+  });
+
+}).call(this);

--- a/site/assets/scripts/simditor.js
+++ b/site/assets/scripts/simditor.js
@@ -336,11 +336,19 @@ Formatter = (function(_super) {
       h3: ['data-indent'],
       h4: ['data-indent']
     };
-    return this.editor.body.on('click', 'a', (function(_this) {
+    if (this.editor.opts.formatter && this.editor.opts.formatter.allowedTags) {
+      this._allowedTags = this.editor.opts.formatter.allowedTags;
+    }
+    if (this.editor.opts.formatter) {
+      $.extend(this._allowedAttributes, this.editor.opts.formatter._allowedAttributes || {});
+    }
+    this.safeFormatter = typeof this.editor.opts.safeFormatter === 'undefined' ? true : this.editor.opts.safeFormatter;
+    this.editor.body.on('click', 'a', (function(_this) {
       return function(e) {
         return false;
       };
     })(this));
+    return console.log(this._allowedAttributes, this._allowedTags, this.safeFormatter, this.editor);
   };
 
   Formatter.prototype.decorate = function($el) {
@@ -460,7 +468,7 @@ Formatter = (function(_super) {
     }
     contents = $node.contents();
     isDecoration = $node.is('[class^="simditor-"]');
-    if ($node.is(this._allowedTags.join(',')) || isDecoration) {
+    if ($node.is(this._allowedTags.join(',')) || isDecoration || !this.safeFormatter) {
       if ($node.is('a') && ($childImg = $node.find('img')).length > 0) {
         $node.replaceWith($childImg);
         $node = $childImg;
@@ -469,12 +477,12 @@ Formatter = (function(_super) {
       if ($node.is('img') && $node.hasClass('uploading')) {
         $node.remove();
       }
-      if (!isDecoration) {
+      if (!(isDecoration || !this.safeFormatter)) {
         allowedAttributes = this._allowedAttributes[$node[0].tagName.toLowerCase()];
         _ref = $.makeArray($node[0].attributes);
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
           attr = _ref[_i];
-          if (!((allowedAttributes != null) && (_ref1 = attr.name, __indexOf.call(allowedAttributes, _ref1) >= 0))) {
+          if (!((allowedAttributes != null) && (_ref1 = attr.name, __indexOf.call(allowedAttributes, _ref1) >= 0) || !this.safeFormatter)) {
             $node.removeAttr(attr.name);
           }
         }
@@ -533,7 +541,7 @@ Formatter = (function(_super) {
           if (children.length > 0) {
             result += _this.clearHtml(children);
           }
-          if (lineBreak && i < contents.length - 1 && $node.is('br, p, div, li, tr, pre, address, artticle, aside, dl, figcaption, footer, h1, h2, h3, h4, header')) {
+          if (lineBreak && i < contents.length - 1 && $node.is('br, p, div, li, tr, pre, address, artticle, aside, dl, figcaption, footer, h1, h2, h3, h4, h5, h6, section, header')) {
             return result += '\n';
           }
         }

--- a/site/assets/scripts/simditor.js
+++ b/site/assets/scripts/simditor.js
@@ -343,12 +343,11 @@ Formatter = (function(_super) {
       $.extend(this._allowedAttributes, this.editor.opts.formatter._allowedAttributes || {});
     }
     this.safeFormatter = typeof this.editor.opts.safeFormatter === 'undefined' ? true : this.editor.opts.safeFormatter;
-    this.editor.body.on('click', 'a', (function(_this) {
+    return this.editor.body.on('click', 'a', (function(_this) {
       return function(e) {
         return false;
       };
     })(this));
-    return console.log(this._allowedAttributes, this._allowedTags, this.safeFormatter, this.editor);
   };
 
   Formatter.prototype.decorate = function($el) {

--- a/site/assets/scripts/uploader.js
+++ b/site/assets/scripts/uploader.js
@@ -79,7 +79,7 @@ Uploader = (function(_super) {
     if (file == null) {
       return;
     }
-    if ($.isArray(file)) {
+    if ($.isArray(file) || file instanceof FileList) {
       for (_i = 0, _len = file.length; _i < _len; _i++) {
         f = file[_i];
         this.upload(f, opts);
@@ -143,7 +143,6 @@ Uploader = (function(_super) {
     return file.xhr = $.ajax({
       url: file.url,
       data: formData,
-      dataType: 'json',
       processData: false,
       contentType: false,
       type: 'POST',
@@ -178,7 +177,8 @@ Uploader = (function(_super) {
       success: (function(_this) {
         return function(result) {
           _this.trigger('uploadprogress', [file, file.size, file.size]);
-          return _this.trigger('uploadsuccess', [file, result]);
+          _this.trigger('uploadsuccess', [file, result]);
+          return $(document).trigger('uploadsuccess', [file, result, _this]);
         };
       })(this),
       complete: (function(_this) {
@@ -259,9 +259,7 @@ uploader = function(opts) {
   return new Uploader(opts);
 };
 
-
 return uploader;
-
 
 }));
 

--- a/site/index-format.html
+++ b/site/index-format.html
@@ -1,0 +1,41 @@
+---
+layout: default
+title: Simditor
+id: demo
+---
+<style>
+	#li_id_1 {
+		color: green;
+	}
+	.li_class_1 {
+		color: blue;
+	}
+</style>
+<section id="page-demo">
+<textarea id="txt-content" data-autosave="editor-content" autofocus>
+<p>Simditor 是团队协作工具 <a href="http://tower.im">Tower</a> 使用的富文本编辑器。</p>
+<p>相比传统的编辑器它的特点是：</p>
+<ul>
+	<li>功能精简，加载快速</li>
+	<li class="li_class_1">输出格式化的标准 HTML</li>
+	<li id="li_id_1">每一个功能都有非常优秀的使用体验</li>
+</ul>
+<p style="color:red">兼容的浏览器：IE10+、Chrome、Firefox、Safari。</p>
+<p style="color:red">这个是红色的字体。</p>
+<code>这是 code 标签</code>
+<svg>
+	svg 标签
+	<rect>rect 标签</rect>
+	<text>text 标签</text>
+</svg>
+<canvas>canvas 标签</canvas>
+<h6>h6标签</h6>
+</textarea>
+</section>
+
+<script type="text/javascript" src="assets/scripts/module.js"></script>
+<script type="text/javascript" src="assets/scripts/uploader.js"></script>
+<script type="text/javascript" src="assets/scripts/hotkeys.js"></script>
+<script type="text/javascript" src="assets/scripts/simditor.js"></script>
+<script type="text/javascript" src="assets/scripts/page-demo-format.js"></script>
+

--- a/src/formatter.coffee
+++ b/src/formatter.coffee
@@ -28,8 +28,6 @@ class Formatter extends SimpleModule
     @editor.body.on 'click', 'a', (e) =>
       false
 
-    console.log @_allowedAttributes, @_allowedTags, @safeFormatter, @editor
-
   decorate: ($el = @editor.body) ->
     @editor.trigger 'decorate', [$el]
 

--- a/src/formatter.coffee
+++ b/src/formatter.coffee
@@ -18,8 +18,17 @@ class Formatter extends SimpleModule
       h3: ['data-indent']
       h4: ['data-indent']
 
+    @_allowedTags = @editor.opts.formatter.allowedTags if @editor.opts.formatter and @editor.opts.formatter.allowedTags
+    $.extend(@_allowedAttributes, @editor.opts.formatter._allowedAttributes || {}) if @editor.opts.formatter
+
+
+
+    @safeFormatter = if typeof @editor.opts.safeFormatter == 'undefined' then true else @editor.opts.safeFormatter
+
     @editor.body.on 'click', 'a', (e) =>
       false
+
+    console.log @_allowedAttributes, @_allowedTags, @safeFormatter, @editor
 
   decorate: ($el = @editor.body) ->
     @editor.trigger 'decorate', [$el]
@@ -106,7 +115,7 @@ class Formatter extends SimpleModule
     contents = $node.contents()
     isDecoration = $node.is('[class^="simditor-"]')
 
-    if $node.is(@_allowedTags.join(',')) or isDecoration
+    if $node.is(@_allowedTags.join(',')) or isDecoration or !@safeFormatter
       # img inside a is not allowed
       if $node.is('a') and ($childImg = $node.find('img')).length > 0
         $node.replaceWith $childImg
@@ -118,10 +127,10 @@ class Formatter extends SimpleModule
         $node.remove()
 
       # Clean attributes except `src` `alt` on `img` tag and `href` `target` on `a` tag
-      unless isDecoration
+      unless isDecoration or !@safeFormatter
         allowedAttributes = @_allowedAttributes[$node[0].tagName.toLowerCase()]
         for attr in $.makeArray($node[0].attributes)
-            $node.removeAttr(attr.name) unless allowedAttributes? and attr.name in allowedAttributes
+            $node.removeAttr(attr.name) unless allowedAttributes? and attr.name in allowedAttributes or !@safeFormatter
     else if $node[0].nodeType == 1 and !$node.is ':empty'
       if $node.is('div, article, dl, header, footer, tr')
         $node.append('<br/>')
@@ -159,7 +168,7 @@ class Formatter extends SimpleModule
         $node = $(node)
         children = $node.contents()
         result += @clearHtml children if children.length > 0
-        if lineBreak and i < contents.length - 1 and $node.is 'br, p, div, li, tr, pre, address, artticle, aside, dl, figcaption, footer, h1, h2, h3, h4, header'
+        if lineBreak and i < contents.length - 1 and $node.is 'br, p, div, li, tr, pre, address, artticle, aside, dl, figcaption, footer, h1, h2, h3, h4, h5, h6, section, header'
           result += '\n'
 
     result


### PR DESCRIPTION
具体其他的 uploader.js 为啥修改了，我猜测是 grunt 编译的结果了。

具体参数：

### safeFormatter [bollean] [可选]
是否开启 safe format 模式。   
为 true 时候，只有白名单 tag + attr 能够通过。   
为 false 时候，任意 tag + attr 即可。   
默认为 true 。    
需求：大部分内部编辑器都是不在乎这个问题，毕竟编辑时候可能并不是 blog 那么简单。    

### formatter [object] [可选]
formatter 参数的对象，其子属性有 `allowedTags` 和 `allowedAttributes` 。

### formatter.allowedTags [array][可选]
@_allowedTags 的拓展，具体为  [https://github.com/mycolorway/simditor/blob/master/src/formatter.coffee#L9](https://github.com/mycolorway/simditor/blob/master/src/formatter.coffee#L9) 的拓展。  
默认为本来的 tag 。   
用于在创建 editor 时候配置，以覆盖形式，新增或者减少白名单 tag 。   

### formatter.allowedAttributes [object][可选]
@_allowedAttributes 的拓展。具体为  [https://github.com/mycolorway/simditor/blob/master/src/formatter.coffee#L10](https://github.com/mycolorway/simditor/blob/master/src/formatter.coffee#L10) 的拓展。  
默认为本来的 attr 。   
用于在创建 editor 时候配置，以拓展key、覆盖 value 形式进行新增或者减少白名单 attr 。   


thanks :)

测试例子为 `/index-format.html`