### PR TITLE
修复 Firefox 浏览器中文IME对 valuechanged 事件的触发

### DIFF
--- a/lib/simditor.js
+++ b/lib/simditor.js
@@ -671,7 +671,7 @@ InputManager = (function(_super) {
         return _this.editor.undoManager.update();
       };
     })(this));
-    this.editor.body.on('keydown', $.proxy(this._onKeyDown, this)).on('keypress', $.proxy(this._onKeyPress, this)).on('keyup', $.proxy(this._onKeyUp, this)).on('mouseup', $.proxy(this._onMouseUp, this)).on('focus', $.proxy(this._onFocus, this)).on('blur', $.proxy(this._onBlur, this)).on('paste', $.proxy(this._onPaste, this)).on('drop', $.proxy(this._onDrop, this));
+    this.editor.body.on('keydown', $.proxy(this._onKeyDown, this)).on('keypress', $.proxy(this._onKeyPress, this)).on('keyup', $.proxy(this._onKeyUp, this)).on('mouseup', $.proxy(this._onMouseUp, this)).on('focus', $.proxy(this._onFocus, this)).on('blur', $.proxy(this._onBlur, this)).on('paste', $.proxy(this._onPaste, this)).on('drop', $.proxy(this._onDrop, this)).on('compositionend', $.proxy(this._onCompositionsend, this)).on('input', $.proxy(this._onInput, this));
     if (this.editor.util.browser.firefox) {
       this.addShortcut('cmd+left', (function(_this) {
         return function(e) {
@@ -1019,6 +1019,18 @@ InputManager = (function(_super) {
         return _this.editor.trigger('valuechanged');
       };
     })(this), 0);
+  };
+
+  InputManager.prototype._onInput = function(e) {
+    if (this.editor.util.browser.firefox && e.originalEvent.isComposing) {
+      return this.editor.trigger('valuechanged', ['composing']);
+    }
+  };
+
+  InputManager.prototype._onCompositionsend = function(e) {
+    if (this.editor.util.browser.firefox) {
+      return this.editor.trigger('valuechanged', ['composing']);
+    }
   };
 
   InputManager.prototype.addKeystrokeHandler = function(key, node, handler) {
@@ -4887,6 +4899,8 @@ StrikethroughButton = (function(_super) {
 
 Simditor.Toolbar.addButton(StrikethroughButton);
 
+
 return Simditor;
+
 
 }));

--- a/site/assets/scripts/simditor.js
+++ b/site/assets/scripts/simditor.js
@@ -671,7 +671,7 @@ InputManager = (function(_super) {
         return _this.editor.undoManager.update();
       };
     })(this));
-    this.editor.body.on('keydown', $.proxy(this._onKeyDown, this)).on('keypress', $.proxy(this._onKeyPress, this)).on('keyup', $.proxy(this._onKeyUp, this)).on('mouseup', $.proxy(this._onMouseUp, this)).on('focus', $.proxy(this._onFocus, this)).on('blur', $.proxy(this._onBlur, this)).on('paste', $.proxy(this._onPaste, this)).on('drop', $.proxy(this._onDrop, this));
+    this.editor.body.on('keydown', $.proxy(this._onKeyDown, this)).on('keypress', $.proxy(this._onKeyPress, this)).on('keyup', $.proxy(this._onKeyUp, this)).on('mouseup', $.proxy(this._onMouseUp, this)).on('focus', $.proxy(this._onFocus, this)).on('blur', $.proxy(this._onBlur, this)).on('paste', $.proxy(this._onPaste, this)).on('drop', $.proxy(this._onDrop, this)).on('compositionend', $.proxy(this._onCompositionsend, this)).on('input', $.proxy(this._onInput, this));
     if (this.editor.util.browser.firefox) {
       this.addShortcut('cmd+left', (function(_this) {
         return function(e) {
@@ -1019,6 +1019,18 @@ InputManager = (function(_super) {
         return _this.editor.trigger('valuechanged');
       };
     })(this), 0);
+  };
+
+  InputManager.prototype._onInput = function(e) {
+    if (this.editor.util.browser.firefox && e.originalEvent.isComposing) {
+      return this.editor.trigger('valuechanged', ['composing']);
+    }
+  };
+
+  InputManager.prototype._onCompositionsend = function(e) {
+    if (this.editor.util.browser.firefox) {
+      return this.editor.trigger('valuechanged', ['composing']);
+    }
   };
 
   InputManager.prototype.addKeystrokeHandler = function(key, node, handler) {
@@ -4887,6 +4899,8 @@ StrikethroughButton = (function(_super) {
 
 Simditor.Toolbar.addButton(StrikethroughButton);
 
+
 return Simditor;
+
 
 }));

--- a/src/inputManager.coffee
+++ b/src/inputManager.coffee
@@ -106,6 +106,8 @@ class InputManager extends SimpleModule
       .on('blur', $.proxy(@_onBlur, @))
       .on('paste', $.proxy(@_onPaste, @))
       .on('drop', $.proxy(@_onDrop, @))
+      .on 'compositionend', $.proxy @_onCompositionsend, @
+      .on 'input', $.proxy @_onInput, @
 
     if @editor.util.browser.firefox
       # fix firefox cmd+left/right bug
@@ -401,6 +403,12 @@ class InputManager extends SimpleModule
       @editor.trigger 'valuechanged'
     , 0
 
+  _onInput: (e) ->
+    if @editor.util.browser.firefox and e.originalEvent.isComposing
+      @editor.trigger 'valuechanged', ['composing']
+  _onCompositionsend: (e) ->
+    if @editor.util.browser.firefox
+      @editor.trigger 'valuechanged', ['composing']
 
   addKeystrokeHandler: (key, node, handler) ->
     @_keystrokeHandlers[key] = {} unless @_keystrokeHandlers[key]


### PR DESCRIPTION
fix #162

use `input` and `compositionend` event to solve this problem just for firfox

references:
https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#events-composition-event-key-events
https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#keys-IME