### PR TITLE
cmd匹配优先，这样webpack等打包程序才能够正确打包simditor。

### DIFF
--- a/umd.hbs
+++ b/umd.hbs
@@ -1,14 +1,14 @@
 (function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    // AMD. Register as an anonymous module unless amdModuleId is set
-    define({{#if amdModuleId}}'{{amdModuleId}}', {{/if}}[{{{amdDependencies.wrapped}}}], function ({{{dependencies}}}) {
-      return ({{#if objectToExport}}root['{{{objectToExport}}}'] = {{/if}}factory({{dependencies}}));
-    });
-  } else if (typeof exports === 'object') {
+  if (typeof exports === 'object') {
     // Node. Does not work with strict CommonJS, but
     // only CommonJS-like environments that support module.exports,
     // like Node.
     module.exports = factory({{{cjsDependencies.wrapped}}});
+  } else if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module unless amdModuleId is set
+    define({{#if amdModuleId}}'{{amdModuleId}}', {{/if}}[{{{amdDependencies.wrapped}}}], function ({{{dependencies}}}) {
+      return ({{#if objectToExport}}root['{{{objectToExport}}}'] = {{/if}}factory({{dependencies}}));
+    });
   } else {
     {{#if globalAlias}}root['{{{globalAlias}}}'] = {{else}}{{#if objectToExport}}root['{{{objectToExport}}}'] = {{/if}}{{/if}}factory({{{globalDependencies.normal}}});
   }


### PR DESCRIPTION
像webpack等打包程序，因为在npm里面simple-module的注册名是simplemodule，所以默认会找不到simple-module。所以需要将cmd模式的查找优先，这样才能够正确打包。