### PR TITLE
fix pasteImage not work

### DIFF
--- a/lib/simditor.js
+++ b/lib/simditor.js
@@ -2326,6 +2326,22 @@ Clipboard = (function(superClass) {
     if (this.editor.triggerHandler('pasting', [pasteContent]) === false) {
       return;
     }
+
+    //  pasteImage 为 false 不插入图片 
+    if (!this.opts.pasteImage) { 
+        var arr = [];
+       jQuery.each(pasteContent, function (index, ele) {
+          if (!$(ele).has('img').length) {
+           arr.push(ele);
+          }
+      });
+       pasteContent.splice(0);
+       $.each(arr,function (index, item) {
+        pasteContent[index] = item;
+       });
+       pasteContent.length = arr.length;
+    }
+
     $blockEl = this._pasteInBlockEl;
     if (!pasteContent) {
       return;


### PR DESCRIPTION
修复`pasteImage`为`false`时，仍然能够从剪切板插入图片。 #446 