### PR TITLE
FIX: textNode with whitespace would generate useless <p> tag

### DIFF
--- a/src/formatter.coffee
+++ b/src/formatter.coffee
@@ -124,7 +124,7 @@ class Formatter extends SimpleModule
     return unless $node.length > 0
 
     if $node[0].nodeType == 3
-      text = $node.text().replace(/(\r\n|\n|\r)/gm, '')
+      text = $node.text().trim().replace(/(\r\n|\n|\r)/gm, '')
       if text
         textNode = document.createTextNode text
         $node.replaceWith textNode


### PR DESCRIPTION
##问题

如果 `textarea` 内不同的标签有空格节点，Simditor 会把空格节点当成一个文本并创建一个没用的 `<p>` 标签。

```html
<textarea>
    <h1>This is a header</h1>
    <p>Lorem ipsum dolor sit amet...</p>
</textarea>
```

this will render
```html
<h1>This is a header</h1>
<p>    </p>
<p>Lorem ipsum dolor sit amet...</p>
```

##解决方案

在 `cleanNode` 方法中对 `textNode` 执行 `trim()` 方法，判断内容是否为空，如果为空则删除该节点。