### PR TITLE
fix: style属性值中包含:号时，被截断的bug

### DIFF
--- a/src/formatter.coffee
+++ b/src/formatter.coffee
@@ -203,7 +203,8 @@ class Formatter extends SimpleModule
     styles = {}
     for style in styleStr.split(';')
       style = $.trim style
-      pair = style.split(':')
+      idx = style.indexOf(':')
+      pair = [style.slice(0, idx), style.slice(idx + 1)]
       continue unless pair.length = 2
       styles[$.trim(pair[0])] = $.trim(pair[1]) if pair[0] in allowedStyles
 


### PR DESCRIPTION
在写第三方查件时发现此bug
当css属性 background-image 值为 url(http://....) 时 editor.getValue() 时 此css值变为 url(http)