### PR TITLE
图片尺寸过大溢出编辑器

### DIFF
--- a/lib/simditor.js
+++ b/lib/simditor.js
@@ -4556,12 +4556,16 @@ ImageButton = (function(superClass) {
     img = new Image();
     img.onload = (function(_this) {
       return function() {
-        var height, width;
+        var height, width, maxWidth = _this.editor.body.width();
         if (!$img.hasClass('loading') && !$img.hasClass('uploading')) {
           return;
         }
         width = img.width;
         height = img.height;
+        if (width > maxWidth) {
+            height = (maxWidth/width) * height;
+            width = maxWidth;
+        }
         $img.attr({
           src: src,
           width: width,


### PR DESCRIPTION
限制图片最大宽度 当图片宽度大于编辑器宽度时调整尺寸 防止溢出
![20171202145403](https://user-images.githubusercontent.com/22412567/33512776-a8a7b726-d770-11e7-90eb-6693b34bfdff.png)
![20171202145325](https://user-images.githubusercontent.com/22412567/33512777-ad114f66-d770-11e7-81fd-85735d8c34a0.png)
