### PR TITLE
add autolink option in config when init simditor

### DIFF
--- a/lib/simditor.js
+++ b/lib/simditor.js
@@ -2486,7 +2486,8 @@ Simditor = (function(superClass) {
     defaultImage: 'images/image.png',
     params: {},
     upload: false,
-    indentWidth: 40
+    indentWidth: 40,
+    autolink: false
   };
 
   Simditor.prototype._init = function() {
@@ -2604,7 +2605,7 @@ Simditor = (function(superClass) {
     cloneBody = this.body.clone();
     this.formatter.undecorate(cloneBody);
     this.formatter.format(cloneBody);
-    this.formatter.autolink(cloneBody);
+    this.opts.autolink && this.formatter.autolink(cloneBody);
     children = cloneBody.children();
     lastP = children.last('p');
     firstP = children.first('p');

--- a/site/_data/configs.yml
+++ b/site/_data/configs.yml
@@ -212,3 +212,8 @@
       { name: 'SQL', value: 'sql'}
     ]
     ```
+- name: 'autolink'
+  type: 'Boolean'
+  default: 'false'
+  description: |
+    When using getValue() method, this option will decide wheather to find url links in the editor, and replace the text with an <a> tag. Keep it text by default.

--- a/site/docs/doc-config.md
+++ b/site/docs/doc-config.md
@@ -24,6 +24,7 @@ editor = new Simditor
   toolbarHidden: false
   pasteImage: false
   cleanPaste: false
+  autolink: false
 ```
 
 


### PR DESCRIPTION
在配置中增加了 autolink 选项，用来启用或者禁用 getValue() 时，是否将链接自动展示为 `<a>` 标签。

调用 getValue() 方法时会默认启用 autolink() 方法，导致本来已经在文本中禁用的链接可能会被再次自动启用。比如 www.google.com 我只希望是文字状态，但是发现每次调用 getValue() 后都会形成 `<a href="http://www.google.com">www.google.com</a>` 的形式。

Add autolink option to config object, to enable or disable autolink function when using simditor.getValue() method.
By default, simditor will automatically replace url text like 'www.google.com' in to a <a> tag when callling getValue() method. This should be configed instead of doing it by default.