### PR TITLE
1  simple-module  simple-uploader 版本问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "dompurify": "^1.0.8",
     "jquery": "^3.3.1",
     "simple-hotkeys": "^1.0.3",
-    "simple-module": "^3.0.3",
-    "simple-uploader": "^3.0.0"
+    "simple-module": " 2.0.6",
+    "simple-uploader": "2.0.8"
   },
   "devDependencies": {
     "express": "~3.3.4",


### PR DESCRIPTION
simple-module  simple-uploader 3.0 版本  copy:script copy:package 2个模块路径不在lib/下，在 dist/下 会打包错误，即使修正路径，打包后simditor 也会出现connect 方法不存在错误