### PR TITLE
CHG: fix bug that removes soft line breaks on pasting content

### DIFF
--- a/lib/simditor.js
+++ b/lib/simditor.js
@@ -618,7 +618,8 @@ Formatter = (function(superClass) {
       return;
     }
     if ($node[0].nodeType === 3) {
-      text = $node.text().replace(/(\r\n|\n|\r)/gm, '');
+      text = $node.text().replace(/(\r\n|\n)/gm, "");
+      text = $node.text().replace(/(\r)/gm, " ");
       if (text) {
         textNode = document.createTextNode(text);
         $node.replaceWith(textNode);


### PR DESCRIPTION
Whenever I copy content from Ms word or some other text editor software, on pasting the content into Simditor,
The **format** function removes soft line breaks and causes some words at the end to merge with each other.
I've fixed that by simply updating the **regex** replace function to add the spaces on soft line breaks.

Here's a few screenshots:
BEFORE the fix:
![image](https://user-images.githubusercontent.com/54110155/145314907-58012860-9d2c-456d-add9-a85537890ceb.png)


AFTER the fix:
![image](https://user-images.githubusercontent.com/54110155/145315036-aaf673b4-28e0-4fa0-8b74-ff440073907a.png)
