### PR TITLE
allow vnc:// as known url prefix

### DIFF
--- a/lib/simditor.js
+++ b/lib/simditor.js
@@ -4241,7 +4241,7 @@ LinkPopover = (function(superClass) {
           return;
         }
         val = _this.urlEl.val();
-        if (!(/^(http|https|ftp|ftps|file)?:\/\/|^(mailto|tel)?:|^\//ig.test(val) || !val)) {
+        if (!(/^(http|https|ftp|ftps|file|vnc)?:\/\/|^(mailto|tel)?:|^\//ig.test(val) || !val)) {
           val = 'http://' + val;
         }
         _this.target.attr('href', val);

--- a/src/buttons/link.coffee
+++ b/src/buttons/link.coffee
@@ -100,7 +100,7 @@ class LinkPopover extends Popover
       return if e.which == 13
 
       val = @urlEl.val()
-      val = 'http://' + val unless /^(http|https|ftp|ftps|file)?:\/\/|^(mailto|tel)?:|^\//ig.test(val) or !val
+      val = 'http://' + val unless /^(http|https|ftp|ftps|file|vnc)?:\/\/|^(mailto|tel)?:|^\//ig.test(val) or !val
 
       @target.attr 'href', val
       @editor.inputManager.throttledValueChanged()


### PR DESCRIPTION
allow vnc as a prefix for an URL (no "http://" should be added when a link starting with vnc is created)